### PR TITLE
FIX #3: Change Provisioning Type from Inline Shell to Path-Based Shell Script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,17 +14,5 @@ Vagrant.configure("2") do |config|
     vb.memory = "4096"
     vb.cpus = 2
   end
-  config.vm.provision "shell", inline: <<-SHELL
-    sudo yum update
-    sudo yum install -y yum-utils
-    sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-    sudo yum install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
-    sudo systemctl start docker
-    sudo systemctl enable docker.service
-    sudo systemctl enable containerd.service
-    sudo yum install git -y
-    sudo groupadd docker
-    sudo usermod -aG docker $USER
-    newgrp docker
-  SHELL
+  config.vm.provision "shell", path: "setup.sh"
 end

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+sudo yum update
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+sudo systemctl start docker
+sudo systemctl enable docker.service
+sudo systemctl enable containerd.service
+sudo yum install git -y
+sudo groupadd docker
+sudo usermod -aG docker $USER
+newgrp docker


### PR DESCRIPTION



**Description:**
This pull request addresses **Issue #3**, which called for changing the provisioning type from inline shell to path-based provisioning. The inline shell commands in the Vagrantfile are now moved to an external script (`setup.sh`), simplifying future modifications and enhancing readability.

**Changes Made:**
1. Created a new `setup.sh` file that contains all the shell commands previously embedded in the Vagrantfile.
2. Updated the Vagrantfile to use path-based shell provisioning that references the newly created `setup.sh` file.